### PR TITLE
Fix sshd issue when Docker is running under Centos 6.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN \
   
   sed -i -r 's/.?UseDNS\syes/UseDNS no/' /etc/ssh/sshd_config && \
   sed -i -r 's/.?PasswordAuthentication.+/PasswordAuthentication no/' /etc/ssh/sshd_config && \
+  sed -i -r 's/.?UsePAM.+/UsePAM no/' /etc/ssh/sshd_config && \
   sed -i -r 's/.?ChallengeResponseAuthentication.+/ChallengeResponseAuthentication no/' /etc/ssh/sshd_config && \
   sed -i -r 's/.?PermitRootLogin.+/PermitRootLogin no/' /etc/ssh/sshd_config && \
 


### PR DESCRIPTION
Authentication is failing when this docker is running under Centos 6.5.
See here for details: http://stackoverflow.com/questions/26539386/ssh-issue-of-docker-in-redhat-6-5