### PR TITLE
Increase memory_limit

### DIFF
--- a/container-files/etc/php.d/zzzz-php.ini
+++ b/container-files/etc/php.d/zzzz-php.ini
@@ -1,0 +1,1 @@
+memory_limit = 2048M


### PR DESCRIPTION
Shell scripts can be very resource hungry, thus it makes sense to increase memory limit just for shell container.

Don't know if it makes sense just for me, if it is just ignore this PR.