### PR TITLE
Add github rate limit detection

### DIFF
--- a/container-files/github-keys.sh
+++ b/container-files/github-keys.sh
@@ -18,14 +18,14 @@ if [ $rate_limit -eq 0 ];
   else
     echo "Importing $user's GitHub pub key(s) to `whoami` account..."
 
-	mkdir -p ~/.ssh
-	if ! [[ -f ~/.ssh/authorized_keys ]]; then
-	  echo "Creating new ~/.ssh/authorized_keys"
-	  touch ~/.ssh/authorized_keys
-	fi
+    mkdir -p ~/.ssh
+    if ! [[ -f ~/.ssh/authorized_keys ]]; then
+      echo "Creating new ~/.ssh/authorized_keys"
+      touch ~/.ssh/authorized_keys
+    fi
 
-	for key in $keys; do
-	  echo "Imported GitHub $user key: $key"
-	  grep -q "$key" ~/.ssh/authorized_keys || echo "$key ${user}@github" >> ~/.ssh/authorized_keys
-	done
+    for key in $keys; do
+      echo "Imported GitHub $user key: $key"
+      grep -q "$key" ~/.ssh/authorized_keys || echo "$key ${user}@github" >> ~/.ssh/authorized_keys
+    done
 fi

--- a/container-files/github-keys.sh
+++ b/container-files/github-keys.sh
@@ -8,17 +8,24 @@
 IFS="$(printf '\n\t')"
 
 user=$1
-keys=`curl -s https://api.github.com/users/$user/keys | grep -o -E "ssh-\w+\s+[^\"]+"`
+api_call=$(curl -v https://api.github.com/users/$user/keys 2>&1)
+rate_limit=$(echo $api_call | grep -o -E 'X-RateLimit-Remaining:\s\d+' | grep -o -E '\d+')
+keys=$(echo $api_call | grep -o -E 'ssh-\w+\s+[^\"]+')
 
-echo "Importing $user's GitHub pub key(s) to `whoami` account..."
+if [ $rate_limit -eq 0 ];
+  then
+    echo "WARNING: Github API rate limit exceeded. No key(s) added to `whoami` account."
+  else
+    echo "Importing $user's GitHub pub key(s) to `whoami` account..."
 
-mkdir -p ~/.ssh
-if ! [[ -f ~/.ssh/authorized_keys ]]; then
-  echo "Creating new ~/.ssh/authorized_keys"
-  touch ~/.ssh/authorized_keys
+	mkdir -p ~/.ssh
+	if ! [[ -f ~/.ssh/authorized_keys ]]; then
+	  echo "Creating new ~/.ssh/authorized_keys"
+	  touch ~/.ssh/authorized_keys
+	fi
+
+	for key in $keys; do
+	  echo "Imported GitHub $user key: $key"
+	  grep -q "$key" ~/.ssh/authorized_keys || echo "$key ${user}@github" >> ~/.ssh/authorized_keys
+	done
 fi
-
-for key in $keys; do
-  echo "Imported GitHub $user key: $key" 
-  grep -q "$key" ~/.ssh/authorized_keys || echo "$key ${user}@github" >> ~/.ssh/authorized_keys
-done


### PR DESCRIPTION
If your API rate limit from GitHub exceeded, no public ssh keys are added. Now a warning message will be displayed.
